### PR TITLE
Temporary fix for broken v-calendar package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "axios": "^0.27.1",
     "eslint": "^7.0.0",
     "lodash": "^4.17.20",
-    "v-calendar": "^2.4.1",
+    "v-calendar": "2.4.1",
     "vue": "^2.6.14",
     "vue-csv-downloader": "^1.0.3",
     "vue-recaptcha": "^2.0.3",


### PR DESCRIPTION
V-Calendar package 2.4.2 breaks our import.

Temporary solution - hard stay at 2.4.1